### PR TITLE
Add support for English texts in toast and commit button detection

### DIFF
--- a/fxbot.js
+++ b/fxbot.js
@@ -928,7 +928,7 @@
   // ===== Commit helpers =====
   function getCommitButton(){
     const btns = Array.from(document.querySelectorAll('button'));
-    return btns.find(b => /Pintar/i.test((b.textContent||'').trim()));
+    return btns.find(b => /(Pintar|Paint)/i.test((b.textContent||'').trim()));
   }
   async function clickCommitOnly(){
     const btn = getCommitButton(); if(!btn) return false;
@@ -963,7 +963,7 @@
       if(state.toast.observer) return;
       const root = getToastRoot();
       state.toast.root = root;
-      const re = /Acabou a tinta|Out of paint/i;
+      const re = /Acabou a tinta|Out of paint|No more charges/i;
       const obs = new MutationObserver((muts)=>{
         if(state.toast.handling) return;
         const now = U.now();


### PR DESCRIPTION
- Extended toast detection to also handle "No more charges" (besides "Acabou a tinta" and "Out of paint").
- Updated commit button selector to match "Paint" in addition to "Pintar".
- Ensures the bot works correctly in English UI without requiring language switch.